### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Strutter
 [![Travis-CI Badge](https://travis-ci.org/Pretz/Strutter.svg?branch=master)](https://travis-ci.org/Pretz/Strutter)
-[![Cocoapods](https://img.shields.io/cocoapods/v/Strutter.svg?style=flat)](http://cocoapods.org/pods/Strutter)
+[![CocoaPods](https://img.shields.io/cocoapods/v/Strutter.svg?style=flat)](http://cocoapods.org/pods/Strutter)
 [![License](https://img.shields.io/cocoapods/l/Strutter.svg?style=flat)](https://github.com/Pretz/Strutter/blob/master/LICENSE)
 [![Platform](https://img.shields.io/cocoapods/p/Strutter.svg?style=flat)](http://cocoapods.org/pods/Strutter)
 
@@ -16,7 +16,7 @@ Since `Strutter` is just syntactic sugar on top of `NSLayoutAnchor`'s methods, i
 
 ### Installation
 
-Strutter supports [Cocoapods](https://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage).
+Strutter supports [CocoaPods](https://cocoapods.org) and [Carthage](https://github.com/Carthage/Carthage).
 
 #### CocoaPods
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
